### PR TITLE
churn repo minor cleanups

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -7,6 +7,20 @@ models:
       entity_key: user
       validity_time: 24h # 1 day
       py_repo_url: https://github.com/rudderlabs/rudderstack-profiles-classifier.git
+
+      train:
+        file_extension: .json
+        file_validity: 168h # If the last trained model is older than this, then the model will be trained again,
+        inputs:
+          - packages/feature_table/models/shopify_user_features
+        config:
+          data:
+            package_name: feature_table # Name of the package where the profiles feature table is defined (declared in pb_project.yaml packages)
+            label_column: is_churned_7_days
+            label_value: 1
+            prediction_horizon_days: 7
+            model_name: 'shopify_user_features'
+
       predict:
         inputs:
           - packages/feature_table/models/shopify_user_features
@@ -19,16 +33,5 @@ models:
               features:
                 - name: *percentile_name
                   description: 'Percentile of churn score. Higher the percentile, higher the probability of churn'
-      train:
-        file_extension: .json
-        file_validity: 60m
-        inputs:
-          - packages/feature_table/models/shopify_user_features
-        config:
-          data:
-            label_column: is_churned_7_days
-            label_value: 1
-            prediction_horizon_days: 7
-            model_name: 'shopify_user_features'
-            
+
       <<: *feature_meta_data


### PR DESCRIPTION
## Description of the change

-Moved train above predict block, and declared variables in train instead of in predict. 
- package name (feature_table) is added now as a config option and commented on its significance.
- Highlighted the significance of train file_validity, and changed the default to 1 week

## Type of change
- Minor Cleanups

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
