### PR TITLE
same configs provided to predict as train

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -6,7 +6,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: /Users/ambuj/Desktop/rudderstack_profiles_classifier
 
       train:
         file_extension: .json
@@ -14,7 +14,7 @@ models:
         inputs:
           - packages/feature_table/models/shopify_user_features
         config:
-          data:
+          data: &model_data_input_configs
             package_name: feature_table # Name of the package where the profiles feature table is defined (declared in pb_project.yaml packages)
             label_column: is_churned_7_days
             label_value: 1
@@ -25,6 +25,7 @@ models:
         inputs:
           - packages/feature_table/models/shopify_user_features
         config:
+          data: *model_data_input_configs
           outputs:
             column_names:
               percentile: &percentile_name percentile_churn_score_7_days

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -6,7 +6,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: user
       validity_time: 24h # 1 day
-      py_repo_url: /Users/ambuj/Desktop/rudderstack_profiles_classifier
+      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json


### PR DESCRIPTION
Changes to be committed:
	modified:   models/profiles.yaml

## Description of the change

> predict configs are customized so that same configs are given to predict as train.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
