### PR TITLE
changing public classifier repo link

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -6,7 +6,7 @@ models:
       occurred_at_col: insert_ts
       entity_key: &entity_name user
       validity_time: 24h # 1 day
-      py_repo_url: git@github.com:rudderlabs/rudderstack-profiles-classifier.git
+      py_repo_url: https://github.com/rudderlabs/rudderstack-profiles-classifier.git
 
       train:
         file_extension: .json

--- a/pb_project.yaml
+++ b/pb_project.yaml
@@ -46,7 +46,7 @@ id_types:
 
 packages:
   - name: feature_table # Do not modify this. If this changes, it needs to be passed to train.py in the config as package_name: <value> and also in the inputs in python_model
-    url: https://github.com/rudderlabs/rudderstack-profiles-shopify-features.git
+    url: https://github.com/rudderlabs/profiles-shopify-features.git
     inputsMap:
       rsCartUpdate: inputs/rsCartUpdate
       rsIdentifies: inputs/rsIdentifies


### PR DESCRIPTION
Changes to be committed:
	modified:   models/profiles.yaml
	modified:   pb_project.yaml

## Description of the change

> Classifier repo has been made public. So, link is changed to https.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
